### PR TITLE
Refactor error handling in platform implementations (Fixes #2).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "postgres 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_postgres 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_sqlite 0.0.1",
+ "r2d2_sqlite 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -274,6 +274,7 @@ dependencies = [
 [[package]]
 name = "r2d2_sqlite"
 version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/platform/sqlite.rs
+++ b/src/platform/sqlite.rs
@@ -8,29 +8,42 @@ use database::SqlOption;
 use rusqlite::SqliteConnection;
 use rusqlite::types::ToSql;
 use rusqlite::SqliteRow;
+use rusqlite::SqliteError;
 use table::{Table, Column, Foreign};
 use database::DatabaseDDL;
 use database::DbError;
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
 use regex::Regex;
+use regex::Error as RegexError;
 use std::collections::BTreeMap;
 
 pub struct Sqlite {
     pool: Option<PooledConnection<SqliteConnectionManager>>,
 }
 
+impl From<SqliteError> for DbError {
+    fn from(err: SqliteError) -> Self {
+        DbError::from_string(format!("{:?}", err))
+    }
+}
+
+impl From<RegexError> for DbError {
+    fn from(err: RegexError) -> Self {
+        DbError::from_string(format!("{:?}", err))
+    }
+}
 
 impl Sqlite{
-    
+
     pub fn new()->Self{
         Sqlite{pool: None}
     }
-    
+
     pub fn with_pooled_connection(pool: PooledConnection<SqliteConnectionManager>)->Self{
        Sqlite{pool: Some(pool)}
     }
-    
+
     fn from_rust_type_tosql<'a>(&self, types: &'a Vec<Value>)->Vec<&'a ToSql>{
         let mut params:Vec<&ToSql> = vec![];
         for t in types{
@@ -43,7 +56,7 @@ impl Sqlite{
         }
         params
     }
-    
+
     pub fn get_connection(&self)->&SqliteConnection{
        if self.pool.is_some(){
             &self.pool.as_ref().unwrap()
@@ -52,7 +65,7 @@ impl Sqlite{
             panic!("No connection for this database")
         }
     }
-    
+
         /// convert a record of a row into rust type
     fn from_sql_to_rust_type(&self, row: &SqliteRow, index:usize)->Value{
         let value = row.get_opt(index as i32);
@@ -61,7 +74,7 @@ impl Sqlite{
             Err(_) => Value::Null,
         }
     }
-    
+
     ///
     /// convert rust data type names to database data type names
     /// will be used in generating SQL for table creation
@@ -125,56 +138,42 @@ impl Sqlite{
         rust_type
 
     }
-    
+
     /// get the foreign keys of table
     fn get_foreign_keys(&self, schema:&str, table:&str)->Vec<Foreign>{
         println!("Extracting foreign keys...");
         let sql = format!("PRAGMA foreign_key_list({});", table);
-        let result = self.execute_sql_with_return(&sql, &vec![]);
+        let result = self.execute_sql_with_return(&sql, &vec![]).unwrap();
         println!("result: {:#?}", result);
-        match result{
-            Ok(result) => {
-                let mut foreigns = vec![];
-                for r in result{
-                    let table: String = r.get("table");
-                    let from: String = r.get("from");
-                    let to: String = r.get("to");
-                    println!("table: {}", table);
-                    println!("from: {}", from);
-                    println!("to: {}", to);
-                    
-                    let foreign = Foreign{
-                        schema: "".to_string(),
-                        table: table.to_string(),
-                        column: to.to_string(),
-                    };
-                    foreigns.push(foreign);
-                }
-                foreigns
-            },
-            Err(e) => {
-                println!("Something is wrong {}", e);
-                vec![]
-            }
+        let mut foreigns = vec![];
+        for r in result{
+            let table: String = r.get("table");
+            let from: String = r.get("from");
+            let to: String = r.get("to");
+            println!("table: {}", table);
+            println!("from: {}", from);
+            println!("to: {}", to);
+
+            let foreign = Foreign{
+                schema: "".to_string(),
+                table: table.to_string(),
+                column: to.to_string(),
+            };
+            foreigns.push(foreign);
         }
+        foreigns
     }
-    
+
     pub fn extract_comments(create_sql: &str)->
                     Result<(Option<String>, BTreeMap<String, Option<String>>),DbError>{
-        let re = match Regex::new(r".*CREATE\s+TABLE\s+(\S+)\s*\((?s)(.*)\).*") {
-            Ok(re) => re,
-            Err(err) => panic!("{}", err),
-        };
+        let re = try!(Regex::new(r".*CREATE\s+TABLE\s+(\S+)\s*\((?s)(.*)\).*"));
         println!("create_sql: {:?}", create_sql);
         if re.is_match(&create_sql){
             println!("matched...");
             let cap = re.captures(&create_sql).unwrap();
             let all_columns = cap.at(2).unwrap();
-            
-            let line_comma_re = match Regex::new(r"[,\n]") {
-                Ok(re) => re,
-                Err(err) => panic!("{}", err),
-            };
+
+            let line_comma_re = try!(Regex::new(r"[,\n]"));
             println!("All columns.. {}", all_columns);
             let splinters:Vec<&str> = line_comma_re.split(all_columns).collect();
             println!("splinters: {:#?}", splinters);
@@ -195,10 +194,10 @@ impl Sqlite{
                     comments.push(Some(splinter.to_string()));
                 }
                 else if splinter.starts_with("FOREIGN"){
-                
+
                 }
                 else if splinter.starts_with("CHECK"){
-                
+
                 }
                 else{
                     let line: Vec<&str> = splinter.split_whitespace().collect();
@@ -228,57 +227,47 @@ impl Sqlite{
     }
     /// extract the comment of the table
     /// Don't support multi-line comment
-    fn get_table_comment(&self, schema:&str, table:&str)->Option<String>{   
+    fn get_table_comment(&self, schema:&str, table:&str)->Option<String>{
         let sql = format!("SELECT sql FROM sqlite_master WHERE type = 'table' AND tbl_name = '{}'",table);
-        let result = self.execute_sql_with_return(&sql, &vec![]);
-        match result{
-            Ok(result) => {
-                assert_eq!(result.len(), 1);
-                let ref dao = result[0];
-                let create_sql:String = dao.get("sql");
-                match Sqlite::extract_comments(&create_sql){
-                    Ok((table_comment, column_comments)) => {
-                        println!("table_comment: {:?}", table_comment);
-                        table_comment
-                    },
-                    Err(e) => {
-                        None
-                    }
-                }
+        let result = self.execute_sql_with_return(&sql, &vec![]).unwrap();
+        assert_eq!(result.len(), 1);
+        let ref dao = result[0];
+        let create_sql:String = dao.get("sql");
+        match Sqlite::extract_comments(&create_sql){
+            Ok((table_comment, column_comments)) => {
+                println!("table_comment: {:?}", table_comment);
+                table_comment
             },
-            Err(e) => None
+            Err(e) => {
+                None
+            }
         }
     }
     /// extract the comments for each column
     /// Don't support multi-line comment
-    fn get_column_comments(&self, schema:&str, table:&str)->BTreeMap<String, Option<String>>{   
+    fn get_column_comments(&self, schema:&str, table:&str)->BTreeMap<String, Option<String>>{
         let sql = format!("SELECT sql FROM sqlite_master WHERE type = 'table' AND tbl_name = '{}'",table);
-        let result = self.execute_sql_with_return(&sql, &vec![]);
-        match result{
-            Ok(result) => {
-                assert_eq!(result.len(), 1);
-                let ref dao = result[0];
-                let create_sql:String = dao.get("sql");
-                match Sqlite::extract_comments(&create_sql){
-                    Ok((table_comment, column_comments)) => {
-                        println!("column_comments: {:?}", column_comments);
-                        column_comments
-                    },
-                    Err(e) => {
-                        BTreeMap::new()
-                    }
-                }
+        let result = self.execute_sql_with_return(&sql, &vec![]).unwrap();
+        assert_eq!(result.len(), 1);
+        let ref dao = result[0];
+        let create_sql:String = dao.get("sql");
+        match Sqlite::extract_comments(&create_sql){
+            Ok((table_comment, column_comments)) => {
+                println!("column_comments: {:?}", column_comments);
+                column_comments
             },
-            Err(e) => BTreeMap::new()
+            Err(e) => {
+                BTreeMap::new()
+            }
         }
     }
-    
+
     fn get_column_comment(&self, column_comments: &BTreeMap<String, Option<String>>, column: &str)->Option<String>{
         match column_comments.get(column){
             Some(comment) => comment.clone(),
             None => None
         }
-    
+
     }
     fn get_column_foreign(&self, all_foreign: &Vec<Foreign>, column: &str)->Option<Foreign>{
         println!("foreign: {:#?} ", all_foreign);
@@ -294,18 +283,12 @@ impl Sqlite{
 impl Database for Sqlite{
     fn version(&self)->String{
        let sql = "select sqlite_version() as version";
-       let dao = self.execute_sql_with_return(sql, &vec![]);
+       let dao = self.execute_sql_with_one_return(sql, &vec![]);
        match dao{
-            Ok(dao) => {
-                if dao.len() == 1{
-                    return dao[0].get("version")
-                }
-                else{
-                    return "unknown".to_string()
-                }
-            },
-            Err(_) => panic!("unable to get database version")
-        }
+           Ok(Some(dao)) => dao.get("version"),
+           Ok(None) => panic!("unable to get database version"),
+           Err(e) => panic!(format!("{:?}", e))
+       }
     }
     fn begin(&self){}
     fn commit(&self){}
@@ -316,7 +299,7 @@ impl Database for Sqlite{
     fn close(&self){}
     fn is_valid(&self)->bool{false}
     fn reset(&self){}
-    
+
     /// return this list of options, supported features in the database
     fn sql_options(&self)->Vec<SqlOption>{
         vec![
@@ -324,17 +307,21 @@ impl Database for Sqlite{
             SqlOption::SupportsCTE,
         ]
     }
-    
+
     fn insert(&self, query:&Query)->Result<Dao, DbError>{
         let sql_frag = self.build_insert(query);
-        self.execute_sql_with_one_return(&sql_frag.sql, &sql_frag.params)
+        match self.execute_sql_with_one_return(&sql_frag.sql, &sql_frag.params) {
+            Ok(Some(result)) => Ok(result),
+            Ok(None) => Err(DbError::new("No result from insert")),
+            Err(e) => Err(e)
+        }
     }
     fn update(&self, query:&Query)->Dao{panic!("not yet")}
     fn delete(&self, query:&Query)->Result<usize, String>{panic!("not yet");}
-    
+
     /// sqlite does not return the columns mentioned in the query,
     /// you have to specify it yourself
-    /// TODO: found this 
+    /// TODO: found this
     /// http://jgallagher.github.io/rusqlite/rusqlite/struct.SqliteStatement.html#method.column_names
     fn execute_sql_with_return(&self, sql:&str, params:&Vec<Value>)->Result<Vec<Dao>, DbError>{
         println!("SQL: \n{}", sql);
@@ -348,47 +335,33 @@ impl Database for Sqlite{
             columns.push(c.to_string());
         }
         println!("columns : {:?}", columns);
-        match stmt.query(&param){
-            Ok(rows) => 
-            for row in rows {
-                match row{
-                    Ok(row) => {
-                        let mut index = 0;
-                        let mut dao = Dao::new();
-                        for col in &columns{
-                            let rtype = self.from_sql_to_rust_type(&row, index);
-                            println!("{:?}",rtype);
-                            dao.set_value(col, rtype);
-                            index += 1;
-                        }
-                        daos.push(dao);
-                    }
-                    Err(e) => {
-                        println!("error! {}",e) 
-                    }
-                }
-            },
-            Err(e) => println!("Something is wrong")
+        let rows = try!(stmt.query(&param));
+        for row in rows {
+            let row = try!(row);
+            let mut index = 0;
+            let mut dao = Dao::new();
+            for col in &columns{
+                let rtype = self.from_sql_to_rust_type(&row, index);
+                println!("{:?}",rtype);
+                dao.set_value(col, rtype);
+                index += 1;
+            }
+            daos.push(dao);
         }
         Ok(daos)
     }
 
-    
-    fn execute_sql_with_one_return(&self, sql:&str, params:&Vec<Value>)->Result<Dao, DbError>{
-        let dao = self.execute_sql_with_return(sql, params);
-        match dao{
-            Ok(dao) => {
-                if dao.len() == 1{
-                    return Ok(dao[0].clone())
-                }
-                else{
-                    return Err(DbError::new("There should be 1 and only 1 record return here"))
-                }
-            },
-            Err(e) => Err(DbError::new("Error in the query"))
+
+    fn execute_sql_with_one_return(&self, sql:&str, params:&Vec<Value>)->Result<Option<Dao>, DbError>{
+        let dao = try!(self.execute_sql_with_return(sql, params));
+        if dao.len() >= 1{
+            return Ok(Some(dao[0].clone()))
+        }
+        else{
+            return Ok(None)
         }
     }
-    
+
     /// generic execute sql which returns not much information,
     /// returns only the number of affected records or errors
     /// can be used with DDL operations (CREATE, DELETE, ALTER, DROP)
@@ -401,7 +374,7 @@ impl Database for Sqlite{
         match result{
             Ok(result) => { Ok(result as usize)},
             Err(e) => {
-                Err(DbError::new(&format!("Something is wrong, {}", e))) 
+                Err(DbError::new(&format!("Something is wrong, {}", e)))
             }
         }
     }
@@ -416,9 +389,9 @@ impl DatabaseDDL for Sqlite{
     fn drop_schema(&self, schema:&str){
         panic!("sqlite does not support schema")
     }
-    
+
     fn build_create_table(&self, table:&Table)->SqlFrag{
-        
+
         fn build_foreign_key_stmt(table: &Table)->SqlFrag{
             let mut w = SqlFrag::new(vec![]);
             let mut do_comma = true;//there has been colcommentsumns mentioned
@@ -436,7 +409,7 @@ impl DatabaseDDL for Sqlite{
             }
             w
         }
-        
+
         let mut w = SqlFrag::new(self.sql_options());
         w.append("CREATE TABLE ");
         w.append(&table.name);
@@ -468,7 +441,7 @@ impl DatabaseDDL for Sqlite{
     }
 
     fn rename_table(&self, table:&Table, new_tablename:String){
-        
+
     }
 
     fn drop_table(&self, table:&Table){
@@ -488,7 +461,7 @@ impl DatabaseDev for Sqlite{
     fn get_table_sub_class(&self, schema:&str, table:&str)->Vec<String>{panic!("not yet")}
 
     fn get_parent_table(&self, schema:&str, table:&str)->Option<String>{panic!("not yet")}
-    
+
     fn get_table_metadata(&self, schema:&str, table:&str, is_view: bool)->Table{
         println!("extracting table meta data in sqlite");
         let sql = format!("PRAGMA table_info({});", table);
@@ -499,7 +472,7 @@ impl DatabaseDev for Sqlite{
                 let foreign = self.get_foreign_keys(schema, table);
                 let table_comment = self.get_table_comment(schema, table);
                 let column_comments = self.get_column_comments(schema, table);
-                
+
                 let mut columns = vec![];
                 for r in result{
                     let column: String = r.get("name");
@@ -512,7 +485,7 @@ impl DatabaseDev for Sqlite{
                     println!("not null: {}", not_null);
                     println!("pk: {}", pk);
                     println!("default_value: {}", default_value);
-                    
+
                     let column_comment = self.get_column_comment(&column_comments, &column);
                     let column_foreign = self.get_column_foreign(&foreign, &column);
                     let column = Column{
@@ -557,7 +530,7 @@ impl DatabaseDev for Sqlite{
                     let is_view = false;
                     tables.push((schema, table, is_view))
                 }
-                tables 
+                tables
             },
             Err(e) => {
                 panic!("Unable to get tables due to {}", e)
@@ -570,7 +543,7 @@ impl DatabaseDev for Sqlite{
     }
 
     fn dbtype_to_rust_type(&self, db_type: &str)->(Vec<String>, String){panic!("not yet")}
-    
+
     fn rust_type_to_dbtype(&self, rust_type: &str)->String{panic!("not yet")}
 }
 
@@ -578,19 +551,19 @@ impl DatabaseDev for Sqlite{
 #[test]
 fn test_comment_extract(){
     let create_sql = r"
-CREATE TABLE product_availability ( 
+CREATE TABLE product_availability (
    --Each product has its own product availability which determines when can it be available for purchase
     product_id uuid NOT NULL , --this is the id of the product
     available boolean,
-    always_available boolean, 
-    stocks numeric DEFAULT 1, 
+    always_available boolean,
+    stocks numeric DEFAULT 1,
     available_from timestamp with time zone,
     available_until timestamp with time zone,
-    available_day json, 
-    open_time time with time zone, 
+    available_day json,
+    open_time time with time zone,
     close_time time with time zone, --closing time
     FOREIGN KEY(product_id) REFERENCES product(product_id)
-)    
+)
     ";
     Sqlite::extract_comments(create_sql);
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -44,7 +44,7 @@ pub enum Direction{
 
 ////
 /// Filter struct merged to query
-/// 
+///
 #[derive(Debug)]
 #[derive(Clone)]
 pub enum Connector{
@@ -110,7 +110,7 @@ pub struct Filter{
 }
 
 impl Filter{
-    
+
     /// user friendly, commonly use API
     pub fn new(column:&str, equality:Equality, value:&ToValue)->Self{
         let right = Operand::Value(value.to_db_type());
@@ -122,7 +122,7 @@ impl Filter{
             subfilters:vec![],
         }
     }
-    
+
     /// user friendly, commonly use API
     pub fn with_value(column:&str, equality:Equality, value: Value)->Self{
         let right = Operand::Value(value);
@@ -134,8 +134,8 @@ impl Filter{
             subfilters:vec![],
         }
     }
-    
-    
+
+
     /// not very commonly used, offers enough flexibility
     pub fn bare_new(left: Operand, equality: Equality, right: Operand)->Self{
         Filter{
@@ -146,29 +146,29 @@ impl Filter{
             subfilters:vec![],
         }
     }
-    
-    
+
+
     pub fn is_null(column:&str)->Self{
         Filter::new(column, Equality::IS_NULL, &())
     }
     pub fn is_not_null(column:&str)->Self{
         Filter::new(column, Equality::IS_NOT_NULL, &())
     }
-    
+
     pub fn and(&mut self, column:&str, equality:Equality, value:&ToValue)->&mut Self{
         let mut filter = Filter::new(column, equality, value);
         filter.connector = Connector::And;
         self.subfilters.push(filter);
         self
     }
-    
+
     pub fn or(&mut self, column:&str, equality:Equality, value:&ToValue)->&mut Self{
         let mut filter = Filter::new(column, equality, value);
         filter.connector = Connector::Or;
         self.subfilters.push(filter);
         self
     }
-    
+
     pub fn or_filter(&mut self, filter: Filter)->&mut Self{
         let mut filter = filter.clone();
         filter.connector = Connector::Or;
@@ -220,7 +220,7 @@ impl Field{
             Operand::ColumnName(ref column_name) => {
                 let rename = column_name.default_rename();
                 Field{
-                    operand:Operand::ColumnName(column_name.clone()), 
+                    operand:Operand::ColumnName(column_name.clone()),
                     name:Some(rename)
                 }
             },
@@ -238,19 +238,19 @@ impl ColumnName{
             let table_split = splinters[0].to_string();
             let column_split = splinters[1].to_string();
             ColumnName{
-                column:column_split.to_string(), 
-                table:Some(table_split.to_string()), 
+                column:column_split.to_string(),
+                table:Some(table_split.to_string()),
                 schema:None,
             }
         } else {
             ColumnName{
-                column:column.to_string(), 
-                table:None, 
+                column:column.to_string(),
+                table:None,
                 schema:None,
             }
         }
     }
-    
+
     fn default_rename(&self)->String{
          if self.table.is_some(){
             return format!("{}_{}", self.table.as_ref().unwrap(), self.column);
@@ -258,7 +258,7 @@ impl ColumnName{
             panic!("Unable to rename {} since table is not specified", self.column);
         }
     }
-    
+
     /// table name and column name
     pub fn complete_name(&self)->String{
         if self.table.is_some(){
@@ -275,7 +275,7 @@ impl ColumnName{
             return self.complete_name();
         }
     }
-    
+
     /// is this column conflicts the other column
     /// conflicts means, when used both in a SQL query, it will result to ambiguous columns
     fn is_conflicted(&self, other:&ColumnName)->bool{
@@ -310,20 +310,20 @@ pub struct TableName{
 }
 
 impl TableName{
-    
+
     pub fn from_str(str: &str)->Self{
         if str.contains("."){
             let splinters = str.split(".").collect::<Vec<&str>>();
             assert!(splinters.len() == 2, "There should only be 2 splinters");
             let schema_split = splinters[0].to_string();
             let table_split = splinters[1].to_string();
-            
+
             TableName{
                 schema: Some(schema_split),
                 name: table_split,
                 columns: vec![],
             }
-            
+
         } else {
              TableName{
                 schema: None,
@@ -332,7 +332,7 @@ impl TableName{
             }
         }
     }
-    
+
     pub fn complete_name(&self)->String{
         match self.schema{
             Some (ref schema) => format!("{}.{}",schema, self.name),
@@ -359,35 +359,35 @@ impl fmt::Display for TableName{
 
 /// convert str, IsTable to TableName
 pub trait ToTableName{
-    
+
     fn to_table_name(&self)->TableName;
-    
+
 }
 
 impl <'a>ToTableName for &'a str{
-    
+
     fn to_table_name(&self)->TableName{
         TableName::from_str(self)
     }
 }
 
 impl ToTableName for str{
-    
+
     fn to_table_name(&self)->TableName{
         TableName::from_str(self)
     }
 }
 
 impl ToTableName for Table{
-    
+
     /// contain the columns for later use when renaming is necessary
     fn to_table_name(&self)->TableName{
         let mut columns = vec![];
         for c in &self.columns{
             let column_name = ColumnName{
-                schema: Some(self.schema.to_string()), 
-                table: Some(self.name.to_string()), 
-                column: c.name.to_string(), 
+                schema: Some(self.schema.to_string()),
+                table: Some(self.name.to_string()),
+                column: c.name.to_string(),
             };
             columns.push(column_name);
         }
@@ -409,68 +409,68 @@ pub enum Error{
 #[derive(Debug)]
 #[derive(Clone)]
 pub struct Query{
-    
+
     ///sql type determine which type of query to form, some fields are not applicable to other types of query
     pub sql_type:SqlType,
-    
+
     /// whether to select the records distinct
     pub distinct: bool,
-    
+
     /// whether to enumate all columns in involved models
     pub enumerate_all: bool,
-    
+
     pub declared_query: BTreeMap<String, Query>,
 
     ///fields can be functions, column sql query, and even columns
     /// TODO; merge enumerated column to this, add a builder for fields
     pub enumerated_fields:Vec<Field>,
-    
-    /// specify to use distinct ON set of columns 
+
+    /// specify to use distinct ON set of columns
     pub distinct_on_columns:Vec<String>,
-    
+
     /// filter records, ~ where statement of the query
     pub filters:Vec<Filter>,
-    
+
     /// joining multiple tables
     pub joins:Vec<Join>,
-    
+
     /// ordering of the records via the columns specified
     /// TODO: ordering should be more flexible than this
     /// needs to support expressions
     pub order_by:Vec<(String, Direction)>,
-    
+
     /// grouping columns to create an aggregate
     pub group_by: Vec<Operand>,
-    
+
     /// having field
     pub having: Vec<Condition>,
-    
+
     /// exclude the mention of the columns in the SQL query, useful when ignoring changes in update/insert records
     pub excluded_columns:Vec<ColumnName>,
-    
+
     /// paging of records
     pub page:Option<usize>,
-    
+
     /// size of a page
     pub page_size:Option<usize>,
-    
+
     /// where the focus of values of column selection
     /// this is the table to insert to, update to delete, create, drop
-    /// whe used in select, this is the 
+    /// whe used in select, this is the
     /// pub from_table:Option<TableName>,
-    
+
     /// from field, where field can be a query, table, column, or function
     pub from:Option<Box<Field>>,
-    
+
     /// The data values, used in bulk inserting, updating,
     pub values:Vec<Operand>,
-    
+
     /// the returning clause of the query when supported,
     pub enumerated_returns: Vec<Field>,
 }
 
 impl Query{
-    
+
     /// the default query is select
     pub fn new()->Self{
         Query{
@@ -493,13 +493,13 @@ impl Query{
             enumerated_returns: vec![],
         }
     }
-    
+
     pub fn select()->Self{
         let mut q = Query::new();
         q.sql_type = SqlType::SELECT;
         q
     }
-    
+
     pub fn insert()->Self{
         let mut q = Query::new();
         q.sql_type = SqlType::INSERT;
@@ -515,13 +515,13 @@ impl Query{
         q.sql_type = SqlType::DELETE;
         q
     }
-    
+
     /// add DISTINCT ie: SELECT DISTINCT
     pub fn distinct(&mut self)->&mut Self{
         self.distinct = true;
         self
     }
-    
+
     pub fn select_all()->Self{
         let mut q = Self::select();
         q.all();
@@ -532,37 +532,37 @@ impl Query{
         q.enumerate_all = true;
         q
     }
-    
+
     pub fn all(&mut self)->&mut Self{
         self.column("*")
     }
-    
+
     fn enumerate(&mut self, column_name: ColumnName)->&mut Self{
         let operand = Operand::ColumnName(column_name);
         let field = Field{operand:operand, name:None};
         self.enumerated_fields.push(field);
         self
     }
-    
+
     /// all enumerated columns shall be called from this
     /// any conflict of columns from some other table will be automatically renamed
     /// columns that are not conflicts from some other table,
     /// but is the other conflicting column is not explicityly enumerated will not be renamed
-    /// 
+    ///
     pub fn column(&mut self, column:&str)->&mut Self{
         let column_name = ColumnName::from_str(column);
         self.enumerate(column_name);
         self
     }
-    
-    
+
+
     pub fn columns(&mut self, columns:Vec<&str>)->&mut Self{
         for c in columns{
             self.column(c);
         }
         self
     }
-    
+
     pub fn group_by(&mut self, columns:Vec<&str>)->&mut Self{
         for c in columns{
             let column_name = ColumnName::from_str(c);
@@ -571,7 +571,7 @@ impl Query{
         }
         self
     }
-    
+
     pub fn having(&mut self, column:&str, equality: Equality, value :&ToValue)->&mut Self{
         let column_name = ColumnName::from_str(column);
         let left = Operand::ColumnName(column_name);
@@ -583,7 +583,7 @@ impl Query{
         self.having.push(cond);
         self
     }
-    
+
     /// exclude columns when inserting/updating data
     /// also ignores the column when selecting records
     /// useful for manipulating thin records by excluding huge binary blobs such as images
@@ -598,7 +598,7 @@ impl Query{
         }
         self
     }
-    
+
     pub fn distinct_on_columns(&mut self, columns:&Vec<String>)->&mut Self{
         let columns = columns.clone();
         for c in columns{
@@ -606,13 +606,13 @@ impl Query{
         }
         self
     }
-    
+
     /// when paging multiple records
     pub fn set_page(&mut self, page:usize)->&mut Self{
         self.page = Some(page);
         self
     }
-    
+
     /// the number of items retrieve per page
     pub fn set_page_size(&mut self, items:usize)->&mut Self{
         self.page_size = Some(items);
@@ -623,7 +623,7 @@ impl Query{
     pub fn limit(&mut self, limit:usize)->&mut Self{
         self.set_page_size(limit)
     }
-    
+
     /// A more terse way to write the query
     pub fn from(&mut self, table: &ToTableName)->&mut Self{
         let table_name = table.to_table_name();
@@ -650,36 +650,36 @@ impl Query{
     pub fn into_table(&mut self, table: &str)->&mut Self{
         self.into_(&table)
     }
-    /// can be used in behalf of into_, from, 
+    /// can be used in behalf of into_, from,
     pub fn table(&mut self, table: &ToTableName)->&mut Self{
         self.from(table)
     }
-    
-    /// if the database support CTE declareted query i.e WITH, 
+
+    /// if the database support CTE declareted query i.e WITH,
     /// then this query will be declared
-    /// if database doesn't support WITH queries, then this query will be 
+    /// if database doesn't support WITH queries, then this query will be
     /// wrapped in the from_query
     /// build a builder for this
     pub fn declare_query(&mut self, query:Query, alias:&str)->&mut Self{
         self.declared_query.insert(alias.to_string(), query);
         self
     }
-    
+
     /// a query to query from
     /// use WITH (query) t1 SELECT from t1 declaration in postgresql, sqlite
-    /// use SELECT FROM (query) in oracle, mysql, others 
+    /// use SELECT FROM (query) in oracle, mysql, others
     /// alias of the table
     pub fn from_query(&mut self, query:Query, alias:&str)->&mut Self{
         let operand = Operand::Query(query);
         let field = Field{operand:operand, name:Some(alias.to_string())};
         self.from_field(field)
     }
-    
+
     pub fn from_field(&mut self, field:Field)->&mut Self{
         self.from = Some(Box::new(field));
         self
     }
-    
+
     pub fn get_from_table(&self)->Option<&TableName>{
         match self.from{
             Some(ref field) => {
@@ -693,16 +693,16 @@ impl Query{
             None => None,
         }
     }
-    
-    
+
+
     /// join a table on this query
     ///
     pub fn join(&mut self, join:Join)->&mut Self{
         self.joins.push(join);
         self
     }
-    
-    
+
+
     /// join a table on this query
     ///
     pub fn left_join_table(&mut self, table:&str, column1:&str, column2:&str)->&mut Self{
@@ -744,7 +744,7 @@ impl Query{
         };
         self.join(join)
     }
-    
+
     pub fn inner_join_table(&mut self, table:&str, column1:&str, column2:&str)->&mut Self{
         self.inner_join(&table, column1, column2)
     }
@@ -758,7 +758,7 @@ impl Query{
         };
         self.join(join)
     }
-    
+
     ///ascending orderby of this column
     pub fn asc(&mut self, column:&str)->&mut Self{
         self.order_by.push((column.to_string(), Direction::ASC));
@@ -769,7 +769,7 @@ impl Query{
         self.order_by.push((column.to_string(), Direction::DESC));
         self
     }
-    
+
     /// get the indexes of the fields that matches the the column name
     fn match_fields_indexes(&self, column: &str)->Vec<usize>{
         let mut indexes = vec![];
@@ -787,7 +787,7 @@ impl Query{
         }
         indexes
     }
-    
+
     /// take the enumerated field that is a column that matched the name
     fn rename_fields(&mut self, column:&str)->&mut Self{
         let matched_indexes = self.match_fields_indexes(column);
@@ -798,7 +798,7 @@ impl Query{
         }
         self
     }
-    
+
     pub fn get_involved_tables(&self)->Vec<TableName>{
         let mut tables = vec![];
         let from_table = self.get_from_table();
@@ -812,7 +812,7 @@ impl Query{
         }
         tables
     }
-    
+
     /// preprocess the missing fields of the query,
     /// such as mentioning the columns of the from_table
     /// enumerate the columns of the involved tables
@@ -822,7 +822,7 @@ impl Query{
     /// if no enumerated fields and no excluded columns
     /// do a select all
     pub fn finalize(&mut self)->&Self{
-        
+
         let involved_models = self.get_involved_tables();
         if involved_models.len() > 1{
             //enumerate all columns when there is a join
@@ -835,13 +835,13 @@ impl Query{
         for i in  excluded_columns{
             self.remove_from_enumerated(&i);
         }
-        if self.excluded_columns.is_empty() 
+        if self.excluded_columns.is_empty()
             && self.enumerated_fields.is_empty(){
             self.all();
         }
         self
     }
-    
+
     fn enumerate_involved_tables_columns(&mut self, involved_models:&Vec<TableName>){
         for m in involved_models{
             for c in &m.columns{
@@ -849,13 +849,13 @@ impl Query{
             }
         }
     }
-    
+
     fn enumerate_from_table(&mut self, table:&TableName){
         for c in &table.columns{
             self.enumerate(c.clone());
         }
     }
-    
+
     fn get_renamed_fields(&self)->Vec<&Field>{
         let mut renamed = vec![];
         for field in &self.enumerated_fields{
@@ -865,7 +865,7 @@ impl Query{
         }
         renamed
     }
-    
+
     /// return the list of renamed columns, used in dao conversion to struc types
     pub fn get_renamed_columns(&self)->Vec<(ColumnName, String)>{
         let mut renamed_columns = vec![];
@@ -883,7 +883,7 @@ impl Query{
         }
         renamed_columns
     }
-    
+
     /// determine which columns are conflicting and rename it accordingly
     /// rename only the columns that are in the enumerated list
     fn get_conflicting_columns(&self)->Vec<String>{
@@ -908,7 +908,7 @@ impl Query{
         }
         self
     }
-    
+
     /// used by removed_from_enumerated
     fn index_of_field(&self, column: &ColumnName)->Option<usize>{
         let mut cnt = 0;
@@ -925,7 +925,7 @@ impl Query{
         }
         None
     }
-    
+
     fn remove_from_enumerated(&mut self, column_name: &ColumnName)->&mut Self{
         let index = self.index_of_field(column_name);
         if index.is_some(){
@@ -933,7 +933,7 @@ impl Query{
         }
         self
     }
-    
+
     /// return the list of enumerated columns
     /// will be used for updating records
     pub fn get_enumerated_columns(&self)->Vec<&ColumnName>{
@@ -948,24 +948,24 @@ impl Query{
         }
         columns
     }
-    
-    
+
+
     pub fn add_filter(&mut self, filter:Filter)->&mut Self{
         self.filters.push(filter);
         self
     }
-    
+
     pub fn add_filters(&mut self, filters:Vec<Filter>)->&mut Self{
         for f in filters{
             self.add_filter(f);
         }
         self
     }
-    
+
     pub fn filter(&mut self, column:&str, equality:Equality, value:&ToValue)->&mut Self{
         self.add_filter(Filter::new(column, equality, value))
     }
-    
+
     /// column = value
     pub fn filter_eq(&mut self, column:&str, value:&ToValue)->&mut Self{
         self.add_filter(Filter::new(column, Equality::EQ, value))
@@ -978,7 +978,7 @@ impl Query{
     pub fn filter_lte(&mut self, column:&str, value:&ToValue)->&mut Self{
         self.add_filter(Filter::new(column, Equality::LTE, value))
     }
-    
+
     /// column > value
     pub fn filter_gt(&mut self, column:&str, value:&ToValue)->&mut Self{
         self.add_filter(Filter::new(column, Equality::GT, value))
@@ -987,34 +987,34 @@ impl Query{
     pub fn filter_gte(&mut self, column:&str, value:&ToValue)->&mut Self{
         self.add_filter(Filter::new(column, Equality::GTE, value))
     }
-    
+
     pub fn add_value(&mut self, value:Operand)->&mut Self{
         self.values.push(value);
         self
     }
-    
+
     pub fn value(&mut self, value:&ToValue)->&mut Self{
         let operand = Operand::Value(value.to_db_type());
         self.add_value(operand)
     }
-    
+
     /// set a value of a column when inserting/updating records
     pub fn set(&mut self, column: &str, value:&ToValue)->&mut Self{
         self.column(column);
         self.value(value)
     }
-    
+
      pub fn return_all(&mut self)->&mut Self{
         self.enumerate_column_as_return("*")
     }
-    
+
     pub fn returns(&mut self, columns: Vec<&str>)->&mut Self{
         for c in columns{
             self.enumerate_column_as_return(c);
         }
         self
     }
-    
+
     pub fn enumerate_column_as_return(&mut self, column:&str)->&mut Self{
         let column_name = ColumnName::from_str(column);
         let operand = Operand::ColumnName(column_name);
@@ -1022,49 +1022,43 @@ impl Query{
         self.enumerated_returns.push(field);
         self
     }
-    
+
     /// build the query only, not executed, useful when debugging
     pub fn build(&mut self, db: &Database)->SqlFrag{
         self.finalize();
         db.build_query(self)
     }
-    
+
     /// expects a return, such as select, insert/update with returning clause
     pub fn retrieve(&mut self, db: &Database)->Result<DaoResult, DbError>{
         self.finalize();
         db.execute_with_return(self)
     }
-    
+
     /// expects a return, such as select, insert/update with returning clause
     /// no casting of data to structs is done
     /// This is used when retrieving multiple models in 1 query, then casting the records to its equivalent structs
-    pub fn retrieve_one(&mut self, db: &Database)->Result<Dao, DbError>{
+    pub fn retrieve_one(&mut self, db: &Database)->Result<Option<Dao>, DbError>{
         self.finalize();
         db.execute_with_one_return(self)
     }
-    
+
     /// delete, update without caring for the return
     pub fn execute(&mut self, db: &Database)->Result<usize, DbError>{
         self.finalize();
         db.execute(self)
     }
-    
+
     /// execute the query, then convert the result
     pub fn collect<T: IsDao+IsTable>(&mut self, db: &Database)->Result<Vec<T>, DbError>{
-        let result = self.retrieve(db);
-        match result{
-            Ok(result) => Ok(result.cast()),
-            Err(e) => Err(DbError::new("Error in the query"))
-        }
+        let result = try!(self.retrieve(db));
+        Ok(result.cast())
     }
-    
+
     /// execute the query then collect only 1 record
     /// TODO: use Result<T,Error> instead of Option<T>
     pub fn collect_one<T: IsDao+IsTable>(&mut self, db: &Database)->Result<T, DbError>{
-        let result = self.retrieve(db);
-        match result{
-            Ok(result) => Ok(result.cast_one().unwrap()),
-            Err(e) => Err(DbError::new("Error in the query"))
-        }
+        let result = try!(self.retrieve(db));
+        Ok(result.cast_one().unwrap())
     }
 }


### PR DESCRIPTION
Using `impl From<T> for DbError` and heavy use of the `try!` macro, the platform implementations are now "bubbling up" the original driver errors instead of panicing and at the same time giving the final user an informative message about what's going on. The code is also a bit easier to read with less nesting.

In my case I now obtain this:

    DbError { description: "Could not connect to address: localhost", cause: None }

instead of a panic with a generic "Error in the query".