### PR TITLE
Introduced an error message if the result of collect_one() is empty

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1059,6 +1059,9 @@ impl Query{
     /// TODO: use Result<T,Error> instead of Option<T>
     pub fn collect_one<T: IsDao+IsTable>(&mut self, db: &Database)->Result<T, DbError>{
         let result = try!(self.retrieve(db));
-        Ok(result.cast_one().unwrap())
+        match result.cast_one() {
+            Some(res) => Ok(res),
+            None => Err(DbError::new("No entry to collect found."))
+        }
     }
 }


### PR DESCRIPTION
I noticed, that this `unwrap()` can panic. So here's a possible fix for it, if you want.
The tests don't pass, but I think they were not passing before :)