### PR TITLE
Implemented different types of errors as enum DbError

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,3 +7,79 @@ pub use self::postgres::Postgres;
 #[cfg(feature = "sqlite")]
 pub use self::sqlite::Sqlite;
 pub use self::mysql::Mysql;
+
+use std::error::Error;
+use std::fmt;
+use postgres::error::Error as PgError;
+use postgres::error::ConnectError as PgConnectError;
+use mysql::error::MyError;
+#[cfg(feature = "sqlite")]
+use rusqlite::SqliteError;
+
+#[derive(Debug)]
+pub enum PlatformError {
+    PostgresError(PgError),
+    PostgresConnectError(PgConnectError),
+    MySQLError(MyError),
+    #[cfg(feature = "sqlite")]
+    SqliteError(SqliteError),
+}
+
+impl Error for PlatformError {
+    fn description(&self) -> &str {
+        match *self {
+            PlatformError::PostgresError(ref err) => err.description(),
+            PlatformError::PostgresConnectError(ref err) => err.description(),
+            PlatformError::MySQLError(ref err) => err.description(),
+            #[cfg(feature = "sqlite")]
+            PlatformError::SqliteError(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            PlatformError::PostgresError(ref err) => Some(err),
+            PlatformError::PostgresConnectError(ref err) => Some(err),
+            PlatformError::MySQLError(ref err) => Some(err),
+            #[cfg(feature = "sqlite")]
+            PlatformError::SqliteError(ref err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for PlatformError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            PlatformError::PostgresError(ref err) => write!(f, "PostgreSQL error: {}", err),
+            PlatformError::PostgresConnectError(ref err) => write!(f, "PostgreSQL connection error: {}", err),
+            PlatformError::MySQLError(ref err) => write!(f, "MySQL error: {}", err),
+            #[cfg(feature = "sqlite")]
+            PlatformError::SqliteError(ref err) => write!(f, "SQlite error: {}", err),
+        }
+    }
+}
+
+impl From<PgError> for PlatformError {
+    fn from(err: PgError) -> Self {
+        PlatformError::PostgresError(err)
+    }
+}
+
+impl From<PgConnectError> for PlatformError {
+    fn from(err: PgConnectError) -> Self {
+        PlatformError::PostgresConnectError(err)
+    }
+}
+
+impl From<MyError> for PlatformError {
+    fn from(err: MyError) -> Self {
+        PlatformError::MySQLError(err)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl From<SqliteError> for PlatformError {
+    fn from(err: SqliteError) -> Self {
+        PlatformError::SqliteError(err)
+    }
+}

--- a/src/platform/mysql.rs
+++ b/src/platform/mysql.rs
@@ -7,7 +7,7 @@ use writer::SqlFrag;
 use database::SqlOption;
 
 use mysql::value::Value as MyValue;
-use mysql::error::{MyResult, MyError};
+use mysql::error::MyResult;
 use mysql::conn::Stmt;
 use mysql::conn::pool::MyPool;
 
@@ -17,12 +17,6 @@ use database::DbError;
 
 pub struct Mysql {
     pool: Option<MyPool>,
-}
-
-impl From<MyError> for DbError {
-    fn from(err: MyError) -> Self {
-        DbError::from_string(format!("{:?}", err))
-    }
 }
 
 impl Mysql{

--- a/src/platform/postgres.rs
+++ b/src/platform/postgres.rs
@@ -6,7 +6,6 @@ use postgres::Connection;
 use regex::Regex;
 use dao::Value;
 use database::{Database, DatabaseDev, DatabaseDDL, DbError};
-use postgres::error::Error as PgError;
 use postgres::types::Type;
 use postgres::types::ToSql;
 use writer::SqlFrag;
@@ -18,12 +17,6 @@ use r2d2_postgres::PostgresConnectionManager;
 pub struct Postgres {
     /// a connection pool is provided
     pub pool: Option<PooledConnection<PostgresConnectionManager>>,
-}
-
-impl From<PgError> for DbError {
-    fn from(err: PgError) -> Self {
-        DbError::from_string(format!("{:?}", err))
-    }
 }
 
 /// Build the Query into a SQL statements that is a valid

--- a/src/platform/sqlite.rs
+++ b/src/platform/sqlite.rs
@@ -8,34 +8,19 @@ use database::SqlOption;
 use rusqlite::SqliteConnection;
 use rusqlite::types::ToSql;
 use rusqlite::SqliteRow;
-use rusqlite::SqliteError;
 use table::{Table, Column, Foreign};
 use database::DatabaseDDL;
 use database::DbError;
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
 use regex::Regex;
-use regex::Error as RegexError;
 use std::collections::BTreeMap;
 
 pub struct Sqlite {
     pool: Option<PooledConnection<SqliteConnectionManager>>,
 }
 
-impl From<SqliteError> for DbError {
-    fn from(err: SqliteError) -> Self {
-        DbError::from_string(format!("{:?}", err))
-    }
-}
-
-impl From<RegexError> for DbError {
-    fn from(err: RegexError) -> Self {
-        DbError::from_string(format!("{:?}", err))
-    }
-}
-
-impl Sqlite{
-
+impl Sqlite {
     pub fn new() -> Self {
         Sqlite { pool: None }
     }
@@ -58,10 +43,9 @@ impl Sqlite{
     }
 
     pub fn get_connection(&self) -> &SqliteConnection {
-        if self.pool.is_some() {
-            &self.pool.as_ref().unwrap()
-        } else {
-            panic!("No connection for this database")
+        match self.pool.as_ref() {
+            Some(conn) => &conn,
+            None => panic!("No connection for this database")
         }
     }
 


### PR DESCRIPTION
I refactored the DbError type as an enum of Error, PoolError and PlatformError.
PlatformError is an enum itself for all the platform specific error types.
All conversions with From::from are implemented to allow transparent propagation.