### PR TITLE
MySQL support improvement

### DIFF
--- a/crates/dao/src/value.rs
+++ b/crates/dao/src/value.rs
@@ -242,6 +242,11 @@ impl<'a> TryFrom<&'a Value> for String {
                 s.push(*v);
                 Ok(s)
             }
+            Value::Blob(ref v) => {
+                String::from_utf8(v.to_owned()).map_err(|e| {
+                    ConvertError::NotSupported(format!("{:?}", value), format!("String: {}", e))
+                })
+            },
             _ => {
                 Err(ConvertError::NotSupported(
                     format!("{:?}", value),


### PR DESCRIPTION
## Add Support Blob to String

Always returns `ColumnType::MYSQL_TYPE_BLOB` from MySQL when SELECT `TEXT` type column.
I added Blob to String conversion support.

## Suppor NON parameterized query
We need transaction system but error returned such as `This command is not supported in the prepared statement protocol yet` in execute `BEGIN` query.
Just run `query()` if params is empty.