### PR TITLE
Some neat picks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ tree_magic = "0.2"
 base64 = "0.9"
 geo = "0.4"
 time = "0.1.14"
-rustorm_dao = "0.4.0"
-rustorm_codegen = "0.3.0"
+rustorm_dao = { path = "crates/dao" }
+rustorm_codegen = { path = "crates/codegen" }
 r2d2_mysql = {version = "16.0.0", optional = true}
 thiserror = "1.0.3"
 
@@ -54,9 +54,3 @@ with-postgres = ["postgres", "r2d2_postgres", "postgres-shared"]
 with-sqlite = ["rusqlite","r2d2_sqlite"]
 with-mysql = ["r2d2_mysql"]
 
-
-# Needed to be here since rustorm is tested as one project
-# in the ci instead of part of diwata
-[replace]
-"rustorm_dao:0.4.0" = { path = "crates/dao" }
-"rustorm_codegen:0.3.0" = { path = "crates/codegen" }

--- a/crates/dao/src/value.rs
+++ b/crates/dao/src/value.rs
@@ -3,7 +3,10 @@ use crate::{
     interval::Interval,
     ConvertError,
 };
-use bigdecimal::{BigDecimal, ToPrimitive};
+use bigdecimal::{
+    BigDecimal,
+    ToPrimitive,
+};
 use chrono::{
     DateTime,
     NaiveDate,
@@ -169,6 +172,7 @@ impl_from!(Uuid, Uuid);
 impl_from!(NaiveDate, Date);
 impl_from!(NaiveTime, Time);
 impl_from!(DateTime<Utc>, Timestamp);
+impl_from!(NaiveDateTime, DateTime);
 
 impl<'a> From<&'a str> for Value {
     fn from(f: &'a str) -> Value { Value::Text(f.to_string()) }
@@ -265,7 +269,7 @@ impl<'a> TryFrom<&'a Value> for String {
                 String::from_utf8(v.to_owned()).map_err(|e| {
                     ConvertError::NotSupported(format!("{:?}", value), format!("String: {}", e))
                 })
-            },
+            }
             _ => {
                 Err(ConvertError::NotSupported(
                     format!("{:?}", value),

--- a/src/table.rs
+++ b/src/table.rs
@@ -167,9 +167,9 @@ impl Table {
 /// if the table in context is product and the foreign table is category
 /// ForeignKey{
 ///     name: product_category_fkey
-///     columns: [category_id]
+///     columns: _category_id_
 ///     foreign_table: category
-///     referred_columns: [id]
+///     referred_columns: _id_
 /// }
 #[derive(Debug, PartialEq, Clone)]
 pub struct ForeignKey {


### PR DESCRIPTION
This PR adds two modifications:

1. Add `NaiveDateTime` to `Value` conversion
2. Use local dependencies of `dao` and `codegen`. This is important because currently rustorm depends on crate.io distributed dao & codegen. This makes depending on the git branch impossible. Thus generally considered as anti-pattern.

By the way, `[replace]` is not used when rustorm is introduced as a lib dependency. So it's also removed.