### PR TITLE
add numeric to bool conversion

### DIFF
--- a/crates/codegen/src/column_derive.rs
+++ b/crates/codegen/src/column_derive.rs
@@ -3,6 +3,7 @@ use syn;
 
 pub fn impl_to_column_names(ast: &syn::MacroInput) -> quote::Tokens {
     let name = &ast.ident;
+    let generics = &ast.generics;
     let fields: Vec<(&syn::Ident, &syn::Ty)> = match ast.body {
         syn::Body::Struct(ref data) => match *data {
             syn::VariantData::Struct(ref fields) => fields
@@ -31,8 +32,7 @@ pub fn impl_to_column_names(ast: &syn::MacroInput) -> quote::Tokens {
         .collect();
 
     quote! {
-        impl rustorm_dao::ToColumnNames for  #name {
-
+        impl #generics rustorm_dao::ToColumnNames for #name #generics {
             fn to_column_names() -> Vec<rustorm_dao::ColumnName> {
                 vec![
                     #(#from_fields)*

--- a/crates/codegen/src/dao_derive.rs
+++ b/crates/codegen/src/dao_derive.rs
@@ -39,6 +39,7 @@ pub fn impl_from_dao(ast: &syn::MacroInput) -> quote::Tokens {
 
 pub fn impl_to_dao(ast: &syn::MacroInput) -> quote::Tokens {
     let name = &ast.ident;
+    let generics = &ast.generics;
     let fields: Vec<(&syn::Ident, &syn::Ty)> = match ast.body {
         syn::Body::Struct(ref data) => match *data {
             syn::VariantData::Struct(ref fields) => fields
@@ -61,8 +62,7 @@ pub fn impl_to_dao(ast: &syn::MacroInput) -> quote::Tokens {
         .collect();
 
     quote! {
-        impl rustorm_dao::ToDao for  #name {
-
+        impl #generics rustorm_dao::ToDao for #name #generics {
             fn to_dao(&self) -> rustorm_dao::Dao {
                 let mut dao = rustorm_dao::Dao::new();
                 #(#from_fields)*

--- a/crates/codegen/src/table_derive.rs
+++ b/crates/codegen/src/table_derive.rs
@@ -3,9 +3,10 @@ use syn;
 
 pub fn impl_to_table_name(ast: &syn::MacroInput) -> quote::Tokens {
     let name = &ast.ident;
-    quote! {
-        impl rustorm_dao::ToTableName for  #name {
+    let generics = &ast.generics;
 
+    quote! {
+        impl #generics rustorm_dao::ToTableName for #name #generics {
             fn to_table_name() -> rustorm_dao::TableName {
                 rustorm_dao::TableName{
                     name: stringify!(#name).to_lowercase().into(),


### PR DESCRIPTION
## Add support numeric value to bool conversion
Bool value be expressed as numeric value in MySQL.

## Add support `ToDato`, `ToTableName`, `ToColumnNames` to borrowed field contained struct
We need insert values with borrowed value because we do not want to clone String.
For example.

```rust
fn insert(mut em: rustorm::EntityManagerMut, message: &str) {
    #[derive(Debug, ToDao, ToTableName, ToColumnNames)]
    struct Row<'b> {
        message: &'b str,
    };

    em.single_insert(&Row { message }).unwrap();
}
```
