### PR TITLE
Upgrade rusqlite and r2d2_sqlite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ url = "1.5"
 cfg-if = "0.1.2"
 uuid = "0.5.1"
 chrono = "0.4.0"
-rusqlite = {version = "0.18", optional = true}
-r2d2_sqlite = {version = "0.10", optional = true}
+rusqlite = {version = "0.21", optional = true}
+r2d2_sqlite = {version = "0.14", optional = true}
 serde = { version = "1.0.15", features = ["derive"] }
 serde_json = "1.0.3"
 byteorder = "1.0"


### PR DESCRIPTION
Got a conflict between this and [refinery](https://github.com/rust-db/refinery) because of mismatching versions so I updated rusqlite and r2d2_sqlite to the newest versions. All the tests still pass. :)